### PR TITLE
Add Siteliner and AnswerThePublic to the list of SEO tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Uncover high-potential keywords to target and captivate your audience.
 - [Serp Miner](https://serpminer.com/free-seo-tools) Free Keyword Research Tools: Find long-tail keywords using Google Autocomplete and check the exact search volume of keywords in bulk.
 
 - [kwrds.ai](https://www.kwrds.ai) - Find great keywords & questions people are asking.
+
+- [AnswerThePublic](https://answerthepublic.com/) - AnswerThePublic visualizes search questions and autocomplete searches in an easy-to-digest keyword research tool that helps you create content ideas.
   
 ## Backlink Analysis
 
@@ -167,6 +169,8 @@ Ensure your website's foundation is solid for search engines and user experience
 - [linkok.com](https://linkok.com) - A modern broken link checker.
 
 - [PressProxy](https://pressproxy.io/) - No-code tool to serve blog.domain.tld on domain.tld/blog using Cloudflare Workers. 
+
+- [Siteliner](https://www.siteliner.com/) -  Siteliner is a free tool that helps identify duplicate content, broken links, and other issues that affect your site's quality and search engine rankings.
 
 
 ## Local SEO


### PR DESCRIPTION
### Summary
This PR adds two new tools, Siteliner and AnswerThePublic, to the curated list of SEO tools:

1. **Siteliner**: Added under the `Technical SEO` category. It helps identify duplicate content, broken links, and other issues affecting site quality.
2. **AnswerThePublic**: Added under the `Keyword Research` category. It visualizes search questions and autocomplete searches, aiding in content creation.

### Changes Made
- Updated the `README.md` file with the new entries.
- Ensured that these tools were not already listed in the repository.

Please review and let me know if any adjustments are needed.
