### PR TITLE
Add Vercel SEO Audit to Technical SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ Ensure your website's foundation is solid for search engines and user experience
 
 - [Server-side Rendering (SSR) Checker](https://www.crawlably.com/ssr-checker/) - Check any URL for SSR (Server-side rendering) by visually comparing server-side rendered version of a page with regular version.
 
+- [Vercel SEO Audit](https://github.com/JosephDoUrden/vercel-seo-audit) - A fast CLI tool that diagnoses SEO and indexing issues for Next.js and Vercel sites, checking redirects, robots.txt, sitemaps, metadata, structured data, and security headers.
+
 ## Local SEO
 
 Boost your local presence and connect with audiences in your community.


### PR DESCRIPTION
[Vercel SEO Audit](https://github.com/JosephDoUrden/vercel-seo-audit) is a fast, open-source CLI tool that diagnoses SEO and indexing issues for Next.js and Vercel sites.

It checks redirects (including Next.js 308 traps), robots.txt, sitemaps, metadata, canonical URLs, structured data (JSON-LD), image SEO, security headers, hreflang tags, and Vercel/Next.js-specific quirks that silently tank rankings.

- Published on npm: [vercel-seo-audit](https://www.npmjs.com/package/vercel-seo-audit)
- MIT licensed
- Supports CI/CD integration with GitHub Actions

I added it to the **Technical SEO** section as it fits alongside other site auditing and crawling tools.