### PR TITLE
Add SEO Score API to Technical SEO section

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ Ensure your website's foundation is solid for search engines and user experience
 - [Server-side Rendering (SSR) Checker](https://www.crawlably.com/ssr-checker/) - Check any URL for SSR (Server-side rendering) by visually comparing server-side rendered version of a page with regular version.
 
 - [LibreCrawl](https://librecrawl.com/) - Free, open-source SEO crawler with unlimited URL crawling, JavaScript rendering via Playwright, and real-time memory profiling for enterprise-scale audits.
+- [SEO Score API](https://seoscoreapi.com/) - API-first SEO audit tool that returns a score (0-100), grade, and 28 checks across meta, technical, social, performance, and accessibility with prioritized fix recommendations. Free tier available.
+
 
 ## Local SEO
 


### PR DESCRIPTION
Adds [SEO Score API](https://seoscoreapi.com/) to the **Technical SEO** section.

SEO Score API is an API-first SEO audit tool that returns a score (0-100), a letter grade, and 28 checks across meta, technical, social, performance, and accessibility categories with prioritized fix recommendations.

- Free tier: 5 audits/day
- [API Documentation](https://seoscoreapi.com/docs)
- Auth: API key
- HTTPS, CORS enabled

Entry placed at the bottom of the Technical SEO section per contribution guidelines.