### PR TITLE
Add Rank4AI to All in one SEO tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ From keyword research to link analysis, these tools are the Swiss army knives of
 
 - [Bishopi.io](https://www.bishopi.io/) - Get Enterprise-Grade SEO and Domain Intelligence.
 
+- [Rank4AI](https://rank4ai.co.uk) - AI search visibility platform for optimizing how businesses appear in ChatGPT, Gemini, Perplexity and Google AI Overviews.
+
 ## Keyword Research
 
 Uncover high-potential keywords to target and captivate your audience.


### PR DESCRIPTION
## Summary

- Adds [Rank4AI](https://rank4ai.co.uk) to the "All in one SEO tools" section

Rank4AI is a UK-based AI search visibility platform that helps businesses optimise how they appear in AI-generated answers across ChatGPT, Gemini, Perplexity and Google AI Overviews. It uses a proprietary Five Signal Model framework covering Identity Clarity, Subject Authority, Meaning Architecture, Ecosystem Validation and Signal Consistency.

Unlike traditional SEO tools that focus on keyword rankings, Rank4AI focuses specifically on generative engine optimization (GEO) — ensuring businesses are accurately interpreted and recommended by AI systems.

**Website:** https://rank4ai.co.uk