### PR TITLE
Add anyserp

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Explore a diverse range of tools for those niche tasks and unique SEO challenges
   
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across AI tools. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+- [anyserp](https://github.com/probeo-io/anyserp) - Unified SERP API router. 11 providers — Serper, SerpAPI, Google CSE, Bing, Brave, DataForSEO, and more.
+
 Happy optimizing! 🚀
 
 ## Information


### PR DESCRIPTION
Add [anyserp](https://github.com/probeo-io/anyserp) to the Miscellaneous Tools section.

anyserp is a unified SERP API router that supports 11 providers — Serper, SerpAPI, Google CSE, Bing, Brave, DataForSEO, and more — through a single consistent interface.