### PR TITLE
Add anyserp — unified SERP API router

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Explore a diverse range of tools for those niche tasks and unique SEO challenges
 
 Happy optimizing! 🚀
 
+- [anyserp](https://github.com/probeo-io/anyserp) - Unified SERP API router. Route search requests across 11 providers (Serper, SerpAPI, Google CSE, Bing, Brave, DataForSEO, and more) with a single API.
 ## Information
 
 This repo is maintained by [SerpApi](https://serpapi.com?utm_source=awesome-seo-tools) team: "Scrape Google and other search engines from our fast, easy, and complete API."


### PR DESCRIPTION
Adds [anyserp](https://github.com/probeo-io/anyserp) to the Miscellaneous Tools section.

**anyserp** is a unified SERP API router that lets you route search requests across 11 providers (Serper, SerpAPI, Google CSE, Bing, Brave, DataForSEO, SearchAPI, ValueSERP, ScrapingDog, Bright Data, SearchCans) with a single API. Self-hosted, zero fees, open source (MIT).

- npm: [@probeo/anyserp](https://www.npmjs.com/package/@probeo/anyserp)
- GitHub: [probeo-io/anyserp](https://github.com/probeo-io/anyserp)