### PR TITLE
Add AI Stack Picks - verified AI & SEO tool pricing comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,3 +319,4 @@ Happy optimizing! 🚀
 ## Information
 
 This repo is maintained by [SerpApi](https://serpapi.com?utm_source=awesome-seo-tools) team: "Scrape Google and other search engines from our fast, easy, and complete API."
+- [AI Stack Picks](https://aistackpicks.com) - Verified pricing comparisons and reviews for 27+ AI and SEO tools, updated monthly with current data from official pricing pages.


### PR DESCRIPTION
Hi! I'd like to add [AI Stack Picks](https://aistackpicks.com) to the Miscellaneous Tools section.

**What it is:** A site that provides verified pricing comparisons for 27+ AI and SEO tools (Semrush, Ahrefs, Moz, etc.) with data pulled directly from official pricing pages.

**Why it's useful for this list:** Most tool comparison sites use outdated pricing. We verify every price by visiting the actual pricing page, noting exact figures, and updating monthly. The [full pricing comparison](https://aistackpicks.com/reviews/ai-tools-pricing-comparison-2026/) covers 5 categories with current data.

Thanks for maintaining this list!