### PR TITLE
Add LinkMeta and OGForge to Social Media & Open Graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,10 @@ Tools for optimizing how your content appears when shared on social platforms.
 
 - [ogimg.xyz](https://ogimg.xyz/) - API for generating Open Graph images programmatically. 10 templates, custom branding, URL auto-fetch mode. Free tier available.
 
+- [LinkMeta](https://linkmeta.dev) - Free URL metadata extraction API for Open Graph, Twitter Cards, and favicons. No API key required.
+
+- [OGForge](https://ogforge.dev) - Free Open Graph image generator API. No API key required.
+
 ## Miscellaneous Tools
 
 Explore a diverse range of tools for those niche tasks and unique SEO challenges.


### PR DESCRIPTION
## Summary

Adds two free SEO-related API tools to the Social Media & Open Graph section:

- **LinkMeta** (linkmeta.dev) - Free URL metadata extraction API for Open Graph, Twitter Cards, and favicons
- **OGForge** (ogforge.dev) - Free Open Graph image generator API

Both tools require no API key and are useful for optimizing social media content visibility.