### PR TITLE
Add aeoptimize — SEO to AEO conversion CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Explore a diverse range of tools for those niche tasks and unique SEO challenges
   
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across AI tools. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+- [aeoptimize](https://github.com/dexuwang627-cloud/aeoptimize) - Open-source CLI that bridges SEO to AEO (Answer Engine Optimization). Scores AI readability (0-100), generates llms.txt and JSON-LD schemas, supports multi-AI scoring. `npx aeoptimize scan your-site.com`
+
 Happy optimizing! 🚀
 
 ## Information


### PR DESCRIPTION
## Adding aeoptimize

[aeoptimize](https://github.com/dexuwang627-cloud/aeoptimize) — open-source CLI that bridges SEO to AEO (Answer Engine Optimization).

### What it does
- **Scan**: AI readability audit (0-100) across 5 dimensions (structure, citability, schema, AI metadata, content density)
- **Generate**: llms.txt, JSON-LD schemas, robots.txt AI crawler suggestions
- **Multi-AI scoring**: Combines scores from multiple AI engines (gemini/copilot)

```bash
npx aeoptimize scan your-site.com
```

npm: [aeoptimize](https://www.npmjs.com/package/aeoptimize) | MIT license