### PR TITLE
Add LinkMeta

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Explore a diverse range of tools for those niche tasks and unique SEO challenges
   
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across AI tools. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+- [LinkMeta](https://linkmeta.dev) - Free URL metadata extraction API that retrieves title, description, Open Graph tags, and other meta information from any URL.
+
 Happy optimizing! 🚀
 
 ## Information


### PR DESCRIPTION
Hi! I'd like to add [LinkMeta](https://linkmeta.dev) to the **Miscellaneous Tools** section.

LinkMeta is a free URL metadata extraction API that retrieves title, description, Open Graph tags, and other meta information from any URL. It's useful for SEO auditing, content previews, and validating how pages will appear in search results and social shares.

The entry has been added at the bottom of the relevant category, following the contribution guidelines.