### PR TITLE
Add SEO for AI to Miscellaneous Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Explore a diverse range of tools for those niche tasks and unique SEO challenges
   
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across AI tools. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+- [SEO for AI](https://getseoforai.com/) - AI search visibility audits for small businesses. Free citation checker and $197 full report covering ChatGPT, Perplexity, Claude, Gemini, and Google AI Overviews.
+
 Happy optimizing! 🚀
 
 ## Information


### PR DESCRIPTION
Per CONTRIBUTING.md: work only on README.md, put link at bottom of relevant category, not already in list.

Adding SEO for AI at the bottom of Miscellaneous Tools. It is an AI search visibility audit service for small businesses with a free checker and $197 full report.

- https://getseoforai.com/
- Free checker: https://getseoforai.com/checker