### PR TITLE
Add AuditWidget to Technical SEO section

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ Ensure your website's foundation is solid for search engines and user experience
 
 - [Moz On-Page Grader](https://moz.com/tools/onpage-grader) - Analyzes individual page optimization.
 
+- [AuditWidget](https://auditwidget.app/?utm_source=awesome-seo-tools&utm_medium=github) - Embeddable SEO audit widget for marketing agencies. Drop a single script tag on your site; visitors run a 12-point SEO analysis and share their email to unlock the full report — turning site visits into qualified leads.
+
 - [BROWSEO](https://www.browseo.net) - See your site through the eyes of a search engine. BROWSEO gives you the type of x-ray vision that search engines have.
 
 - [linkok.com](https://linkok.com) - A modern broken link checker.

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Ensure your website's foundation is solid for search engines and user experience
 
 - [Moz On-Page Grader](https://moz.com/tools/onpage-grader) - Analyzes individual page optimization.
 
-- [AuditWidget](https://auditwidget.app/?utm_source=awesome-seo-tools&utm_medium=github) - Embeddable SEO audit widget for marketing agencies. Drop a single script tag on your site; visitors run a 12-point SEO analysis and share their email to unlock the full report — turning site visits into qualified leads.
+- [AuditWidget](https://auditwidget.app/?utm_source=github&utm_medium=awesome_list&utm_campaign=awesome-seo-tools) - Embeddable SEO audit widget for marketing agencies. Drop a single script tag on your site; visitors run a 12-point SEO analysis and share their email to unlock the full report — turning site visits into qualified leads.
 
 - [BROWSEO](https://www.browseo.net) - See your site through the eyes of a search engine. BROWSEO gives you the type of x-ray vision that search engines have.
 


### PR DESCRIPTION
Adding [AuditWidget](https://auditwidget.app/) to the Technical SEO section.

**What it does:** Embeddable SEO audit widget for marketing agencies. Drop a `<script>` tag on your site — visitors run a 12-point SEO analysis (title tags, meta, HTTPS, mobile, page speed, canonicals, etc.) and share their email to unlock the full report. Every audit becomes a captured lead.

- Live at https://auditwidget.app
- Free plan: 5 audits/month, no credit card required
- Fully functional — no waitlist

Disclosure: I am the creator of AuditWidget.