### PR TITLE
Add SEOintent to All in one SEO tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ From keyword research to link analysis, these tools are the Swiss army knives of
 - [SEO Toolbox](https://seotoolbox.site) – An all-in-one SEO platform that combines page-by-page analysis with AI powered insights and in-depth report generation, built for everyone from individuals to SEO agencies.
 
 - [Bishopi.io](https://www.bishopi.io/) - Get Enterprise-Grade SEO and Domain Intelligence.
+- [SEOintent](https://seointent.com) - AI SEO platform that auto-clusters keywords, generates SEO-optimized articles with Claude, tracks AI citations across ChatGPT/Perplexity/Gemini, and publishes directly to WordPress, Shopify, Webflow, or Ghost. Built for agencies and SaaS teams.
+
 
 ## Keyword Research
 


### PR DESCRIPTION
Hi! Adding SEOintent — an AI SEO platform that pairs content generation with AI citation tracking (ChatGPT, Perplexity, Claude, Gemini) and direct CMS publishing.

Built specifically for the gap your 'All in one SEO tools' section addresses: SEO teams that want one platform instead of stacking Surfer + Jasper + Ahrefs + a separate AI tracker.

- Live: https://seointent.com
- Free 14-day trial, no card required
- Pricing: Growth $99/mo, Scale $199/mo (with white-label)

Followed your contribution guidelines (README.md only, alphabetically near the bottom of the relevant category, doesn't duplicate existing entries).

Thanks for maintaining this list — it's a great resource.