### PR TITLE
Add AI Visibility Monitor (open-source AI citation tracker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Explore a diverse range of tools for those niche tasks and unique SEO challenges
   
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across AI tools. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+- [AI Visibility Monitor](https://github.com/WorkSmartAI-alt/ai-visibility-monitor) - Open-source Python toolkit that tracks whether ChatGPT, Claude, and Perplexity cite your site. MIT license, runs locally on your credentials.
+
 Happy optimizing! 🚀
 
 ## Information


### PR DESCRIPTION
Adds AI Visibility Monitor to the Miscellaneous Tools section, alongside the existing GEO/AEO Tracker entry.

What it does: open-source Python toolkit that tracks whether ChatGPT, Claude, Perplexity, and Gemini cite your site for buyer-intent queries. Pulls Google Search Console and GA4 data, checks robots.txt and llms.txt for AI bot crawl readiness, and runs Claude with web_search to record citation patterns.

License: MIT
Cost to run: \$1-3 per citation check via Anthropic API; rest is free
Repo: https://github.com/WorkSmartAI-alt/ai-visibility-monitor

Built for solo operators and lean consulting practices priced out of \$300-500/month SaaS alternatives like Otterly, Peec, and Profound.

Disclosure: I'm the maintainer of the AI Visibility Monitor repo.