### PR TITLE
Add PromptEden to SEO Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ Boost your local presence and connect with audiences in your community.
  
 - [SEO Gets](https://seogets.com/) - Privacy-focused analytics tool built to replace Google Search Console for Agencies and Affiliates.
 
+- [PromptEden](https://www.prompteden.com) - AEO (Answer Engine Optimization) monitoring: track how ChatGPT, Claude, Gemini, Perplexity, Copilot, and Grok describe your brand and which competitors they recommend instead.
+
 ## SEO Browser Extensions
 
 Equip your browser with tools for quick and efficient SEO insights on the go.


### PR DESCRIPTION
Adds [PromptEden](https://www.prompteden.com) to the **SEO Analytics** section.

### What it is

PromptEden is an AEO (Answer Engine Optimization) monitoring platform. It tracks how ChatGPT, Claude, Gemini, Perplexity, Copilot, and Grok describe your brand and which competitors they recommend instead — running prompts daily across 9+ AI platforms and surfacing visibility scores, competitor mentions, and citation sources.

### Why it fits this list

AEO is the SEO discipline for AI answer engines. As LLM assistants become a meaningful share of category-research traffic, knowing what they say about you is the analytics analogue to Search Console for the AI era. Placed under *SEO Analytics* alongside Search Console / SEO Gets — happy to move it elsewhere if you'd prefer a new "AEO / AI Search" subsection.

### Contribution checklist

- [x] Edited `README.md` only
- [x] Link is valid; not already in the list (grep'd `prompteden`)
- [x] Placed at the bottom of a relevant category (per contributing rules)
- [x] Description is concise and factual