### PR TITLE
Add calcfuel - free marketing calculator suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Explore a diverse range of tools for those niche tasks and unique SEO challenges
   
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across AI tools. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+- [calcfuel](https://calcfuel.com) - Free suite of 35+ marketing calculators (ROI, ROAS, CAC, CLV, CTR, and more) to help measure and optimize marketing performance.
+
 Happy optimizing! 🚀
 
 ## Information


### PR DESCRIPTION
## Description

Adding [calcfuel](https://calcfuel.com) to the Miscellaneous Tools section.

**calcfuel** is a free suite of 35+ marketing calculators covering ROI, ROAS, CAC, CLV, CTR, and more. No signup required, no paywall.

It helps marketers measure and optimize performance across paid, organic, and email channels.

## Checklist
- [x] Added to the bottom of the Miscellaneous Tools section
- [x] Link is live and functional
- [x] No duplicate in existing list