### PR TITLE
Add IndexNow and AI crawler SEO utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Ensure your website's foundation is solid for search engines and user experience
 
 - [LibreCrawl](https://librecrawl.com/) - Free, open-source SEO crawler with unlimited URL crawling, JavaScript rendering via Playwright, and real-time memory profiling for enterprise-scale audits.
 
+- [IndexNow Changed URL Payload Builder](https://indexnow-payload-builder.vercel.app/) - Free, no-tracking browser utility for preparing same-host IndexNow JSON payloads, curl commands, checklists, Markdown notes, and CSV launch-log rows.
+
 ## Local SEO
 
 Boost your local presence and connect with audiences in your community.

--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ Equip your browser with tools for quick and efficient SEO insights on the go.
 
 - [Robots.txt Checker](https://support.google.com/webmasters/answer/6062598?hl=en) - Checks robots.txt files for errors.
 
+- [AI Crawler Robots.txt Builder](https://ai-crawler-robots-builder.vercel.app/) - Free no-tracking browser utility for generating and checking AI crawler robots.txt rules for GPTBot, OAI-SearchBot, ClaudeBot, Google-Extended, and PerplexityBot.
+
 - [Lighthouse Rich Result Checker](https://search.google.com/test/rich-results) - Tests whether your website is eligible for rich results in Google Search.
 
 - [XML Sitemap Checker](https://www.xml-sitemaps.com/validate-xml-sitemap.html) - Validates XML sitemaps for errors.


### PR DESCRIPTION
Adds a README-only Technical SEO entry for IndexNow Changed URL Payload Builder.

Why it fits:
- Technical SEO utility for preparing IndexNow JSON payloads and curl commands.
- Browser-only and no-tracking; it prepares output locally and does not submit URLs.
- Adjacent to webmaster/search-console tooling, but distinct from server/MCP submission tools.

Disclosure: I maintain the linked tool.