### PR TITLE
Add TinyTools OG Image Generator to Social Media & Open Graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ Tools for optimizing how your content appears when shared on social platforms.
 
 - [ogimg.xyz](https://ogimg.xyz/) - API for generating Open Graph images programmatically. 10 templates, custom branding, URL auto-fetch mode. Free tier available.
 
+- [TinyTools OG Image Generator](https://tinytools-smoky.vercel.app/) - Free browser-based Open Graph image generator. Create custom OG/Twitter card images with multiple templates, fonts, and gradients. No signup, all processing in-browser. Part of TinyTools open-source utility suite (favicon, color palette, SEO meta tag generators).
+
 ## Miscellaneous Tools
 
 Explore a diverse range of tools for those niche tasks and unique SEO challenges.


### PR DESCRIPTION
Adds [TinyTools OG Image Generator](https://tinytools-smoky.vercel.app/) to the **Social Media & Open Graph** section.

TinyTools is a free, open-source suite of single-purpose web utilities. The OG Image Generator helps users create custom Open Graph and Twitter card images directly in the browser — multiple templates, fonts, gradients, and color schemes. Generated images can be downloaded as PNG.

**Why it fits the section:**
- Browser-based Open Graph image generator (no signup, no installation)
- All processing happens locally in-browser (privacy-friendly)
- Free and part of an open-source utility suite
- Complements existing entries like ShotOG and ogimg.xyz with a fully-client-side, no-API alternative

Tool link: https://tinytools-smoky.vercel.app/