### PR TITLE
Add four Apify-hosted SEO/audit tools to Technical SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,14 @@ Ensure your website's foundation is solid for search engines and user experience
 
 - [LibreCrawl](https://librecrawl.com/) - Free, open-source SEO crawler with unlimited URL crawling, JavaScript rendering via Playwright, and real-time memory profiling for enterprise-scale audits.
 
+- [Lighthouse Auditor](https://apify.com/accurate_pouch/lighthouse-auditor) - Batch PageSpeed Insights API runner with Core Web Vitals tracking and competitor comparison.
+
+- [Tech Stack Detector](https://apify.com/accurate_pouch/tech-stack-detector) - Website technology detection with 7,517 signatures across 105 categories (Wappalyzer-style database).
+
+- [Broken Link Checker](https://apify.com/accurate_pouch/broken-link-checker) - Recursive site crawler that parses sitemaps and robots.txt to find broken links, with webhook alerts.
+
+- [Security Headers Scanner](https://apify.com/accurate_pouch/security-headers) - Audits 12 OWASP-recommended HTTP security headers with A+ to F grading.
+
 ## Local SEO
 
 Boost your local presence and connect with audiences in your community.


### PR DESCRIPTION
Adding four hosted tools used in SEO and site-audit workflows. All deployed on Apify Store and runnable via REST API or one-click in the Apify Console.

- **Lighthouse Auditor** — Batch PageSpeed Insights API runner with Core Web Vitals tracking and delta-against-previous-run comparison.
- **Tech Stack Detector** — 7,517 signatures across 105 categories (Wappalyzer-style database). Implies-chain detection (e.g. Next.js implies Node.js, React).
- **Broken Link Checker** — Recursive site crawler with sitemap.xml + robots.txt parsing, severity classification, and webhook alerts.
- **Security Headers Scanner** — Audits 12 OWASP-recommended HTTP headers (CSP, HSTS, X-Frame-Options, etc.) and grades A+ through F.

Placed at the bottom of `## Technical SEO` per maintainer rule ("put the link at the bottom of the relevant category"). Happy to relocate if you'd prefer them spread across categories — Broken Link Checker fits Validator/Checker too, for example.

Pricing: Tech Stack Detector $0.02/URL; Lighthouse, Broken Link Checker, Security Headers $0.003/op today (utility tools transitioning to $0.004 effective 2026-05-28 per Apify's 14-day notice policy).