### PR TITLE
Add The SEO Autopilot to All in one SEO tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ From keyword research to link analysis, these tools are the Swiss army knives of
 
 - [Bishopi.io](https://www.bishopi.io/) - Get Enterprise-Grade SEO and Domain Intelligence.
 
+- [The SEO Autopilot](https://the-seo-autopilot.com) - Autonomous AI agent that runs the full SEO pipeline (keyword research, fact-checked drafts, schema markup, internal linking, scheduling) for indie SaaS founders — plus 13 free in-browser SEO tools (llms.txt generator, JSON-LD schema, SERP CTR calculator, hreflang, canonical, robots, AI overview checker, AI content cost calculator).
+
 ## Keyword Research
 
 Uncover high-potential keywords to target and captivate your audience.


### PR DESCRIPTION
Hi! Adds [The SEO Autopilot](https://the-seo-autopilot.com) to the **All in one SEO tools** section. It's an autonomous AI-agent SEO system aimed at indie SaaS founders that ships a free in-browser tool suite (llms.txt generator, JSON-LD schema generator, SERP CTR calculator, hreflang/canonical/robots tag generators, AI overview checker, AI content cost calculator) at https://the-seo-autopilot.com/en/free-tools/ — plus a paid playbook tier with the implementation prompts.

Followed the contributing notes (only edits `README.md`, appended to the bottom of the relevant category, checked it isn't already in the list).

Happy to adjust the wording or move it to a different category if you'd prefer.