### PR TITLE
Add FeedPulse — free all-in-one SEO checker with transparent data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ From keyword research to link analysis, these tools are the Swiss army knives of
 - [SEO Toolbox](https://seotoolbox.site) – An all-in-one SEO platform that combines page-by-page analysis with AI powered insights and in-depth report generation, built for everyone from individuals to SEO agencies.
 
 - [Bishopi.io](https://www.bishopi.io/) - Get Enterprise-Grade SEO and Domain Intelligence.
+- [FeedPulse](https://feed-pulse.com/) - 100% free all-in-one SEO checker suite (Traffic Rank, DA, DR, Backlinks, SERP, Index, Lighthouse, Speed, Trust, Age) with [transparent data-source disclosure](https://feed-pulse.com/data-sources) for every metric. No signup, no upsell.
 
 ## Keyword Research
 


### PR DESCRIPTION
Adds FeedPulse to the "All in one SEO tools" section.

FeedPulse is a 100% free SEO checker suite covering 10 tools (Traffic Rank, DA,
DR, Trust Score, Backlinks, SERP Position, Google Index, Lighthouse, Page
Speed, Domain Age). No signup, no rate-limit lifting upsell, no upsell at all.

Why I think it deserves a slot: most free SEO tools don't disclose which data
sources they use. FeedPulse routes through Tranco (rank), Moz Links API (DA),
OpenPageRank (DR), Serper.dev → SerpAPI → DDG fallback chain (SERPs), and
Google PageSpeed Insights — and publishes the full provider methodology +
refresh cadence at https://feed-pulse.com/data-sources

Confirms with contributing rules:
- Single-line entry added at the bottom of "All in one SEO tools"
- Tool not already on the list
- README.md only