### PR TITLE
Add @unlocksaas/seo to Technical SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Ensure your website's foundation is solid for search engines and user experience
 
 - [LibreCrawl](https://librecrawl.com/) - Free, open-source SEO crawler with unlimited URL crawling, JavaScript rendering via Playwright, and real-time memory profiling for enterprise-scale audits.
 
+- [@unlocksaas/seo](https://www.npmjs.com/package/@unlocksaas/seo) - Open-source CLI (MIT) that fetches a deployed page, parses every JSON-LD block, and reports honesty violations (fabricated `aggregateRating`, non-https `sameAs`, malformed ISO dates) plus drift between schema claims and the rendered HTML. Also generates `/llms.txt` and `/llms-feed.json`. Exits non-zero in CI.
+
 ## Local SEO
 
 Boost your local presence and connect with audiences in your community.


### PR DESCRIPTION
Adds [@unlocksaas/seo](https://www.npmjs.com/package/@unlocksaas/seo) to the Technical SEO section, alongside SEOnaut and Python SEO Analyzer.

Open-source CLI (MIT) that audits any deployed page for fabricated JSON-LD and drift between schema claims and rendered HTML:

- Catches `aggregateRating` with `reviewCount: 0` — the most common AI-Overview demotion trigger
- Catches `sameAs` entries without an https scheme
- Catches free-text dates that validators silently drop
- Diffs FAQ questions, Article headlines, and Offer prices against the visible page
- Generates `/llms.txt` and `/llms-feed.json` for AI-search discovery

Zero runtime dependencies. Exits non-zero in CI on any violation. Framework-free; Next.js is an optional helper.

Followed the contribution rules:
- README-only edit
- Added at the bottom of the relevant category (Technical SEO)
- Verified the link does not already exist in the list