### PR TITLE
Add AgentGrade to Validator / Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ Equip your browser with tools for quick and efficient SEO insights on the go.
 
 - [XML Sitemap Checker](https://www.xml-sitemaps.com/validate-xml-sitemap.html) - Validates XML sitemaps for errors.
 
+- [AgentGrade](https://agentgrade.com/) - Scans websites for AI agent readiness, validating MCP servers, llms.txt, OpenAPI specs, content negotiation, and 70+ other signals AI agents look for.
+
 
 ## Social Media & Open Graph
 


### PR DESCRIPTION
Adds AgentGrade to the **Validator / Checker** section.

AgentGrade scans any URL across 70+ checks to grade how ready a website is for AI agents and answer engines — covering MCP servers, llms.txt, x402 payment headers, OpenAPI specs, content negotiation, robots.txt for agents, and similar emerging signals. Returns a 0-100 score with per-check remediation hints linked to a Knowledge Base. Free, no signup.

- Site: https://agentgrade.com
- Public leaderboard ranking top 100 sites: https://agentgrade.com/leaderboard/

Placed at the bottom of the Validator / Checker section per the contribution guidelines. Confirmed it's not already in the list.
