### PR TITLE
Add crawlgraph to Backlink Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Delve deep into your link profile and discover opportunities for growth and risk
 
 - [Majestic](https://majestic.com/) - Find out who links to your website.
 
+- [crawlgraph](https://crawlgraph.com/) - Free backlink intelligence built on the public Common Crawl web graph (4.4B edges, 120M domains). Paste a competitor, export every referring domain as CSV. 5 free queries, $99 lifetime for unlimited.
+
 - [Monitor Backlinks](https://monitorbacklinks.com/) - Check the good and bad backlinks for you and the competition.
 
 - [Respona](https://respona.com/) - The all in one link building tool.


### PR DESCRIPTION
## What

Adds [crawlgraph](https://crawlgraph.com/) to the Backlink Analysis section.

## Why it fits

The section already lists Majestic, Monitor Backlinks, BacklinkGPT, BacklinkScan, and others. crawlgraph belongs in the same group but takes a different approach: rather than running its own continuous crawler, it indexes the public [Common Crawl](https://commoncrawl.org) web graph (4.4B edges, 120M domains, quarterly release).

Practically:
- **Free tier:** 5 queries, no signup
- **Paid:** $99 lifetime (no monthly)
- **Methodology:** Open and documented (every result is dated to the source CC release)
- **Use case:** Outreach prospecting — paste a competitor, export every site linking to them as CSV

It doesn't replace ahrefs for live signal monitoring (Common Crawl is quarterly, so deltas lag 30–90 days), but for one-off prospecting lists it's a fair option to surface in this list.

## Disclosure

I'm the maintainer of crawlgraph. Happy to revise or move the entry if there's a better fit. Thanks for maintaining this list.