### PR TITLE
Add SiteRacer to Miscellaneous Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Explore a diverse range of tools for those niche tasks and unique SEO challenges
   
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across AI tools. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+- [SiteRacer](https://siteracer.com) - Compares your site's load speed against up to three competitors, with hosting, CDN and caching detection and prioritized fixes.
+
 Happy optimizing! 🚀
 
 ## Information


### PR DESCRIPTION
Adds [SiteRacer](https://siteracer.com) at the bottom of the Miscellaneous Tools category, per the contributing guidelines.

SiteRacer is a free, no-signup website speed tool that benchmarks your site's performance side-by-side against up to three competitors and detects hosting/CDN/caching to suggest prioritized improvements. It sits naturally next to the other hosted speed tools already listed here (GTmetrix, Pingdom, DebugBear). Verified it's not already in the list; single-line addition with matching format.