### PR TITLE
Add SellerMind - Etsy keyword research & listing optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ Explore a diverse range of tools for those niche tasks and unique SEO challenges
   
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across AI tools. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+- [SellerMind](https://thesellermind.com/) - AI-powered Etsy SEO tool for listing optimization, fee calculation, and data-driven pricing insights.
 Happy optimizing! 🚀
 
 ## Information


### PR DESCRIPTION
Adds [SellerMind](https://thesellermind.com) to the **Keyword Research** section.

**Description:** SellerMind is an indie-built Etsy SEO research tool. Keyword volume, competition data, competitor listing snapshots, AI-assisted listing rewriter (title, tags, description), trend & seasonality views. Targets solo Etsy sellers who want simpler pricing than the established multi-tier platforms.

**Why it fits this list:** Same category as the existing Keyword Research entries (Google Keyword Planner, Keyword Tool, Ahrefs' Keywords Generator, Semrush, AnswerThePublic, etc.) but specialized for the Etsy marketplace, which isn't represented yet in this section. Format follows the existing `- [Name](link) - Description.` template, ends with a period, and is appended to the bottom of the relevant category per the README's contribution rules.

Homepage: https://thesellermind.com