### PR TITLE
Add TrustYourWebsite to Technical SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Ensure your website's foundation is solid for search engines and user experience
 
 - [LibreCrawl](https://librecrawl.com/) - Free, open-source SEO crawler with unlimited URL crawling, JavaScript rendering via Playwright, and real-time memory profiling for enterprise-scale audits.
 
+- [TrustYourWebsite](https://trustyourwebsite.com) - Automated GDPR, cookie banner and accessibility (axe-core) compliance scanner for EU and UK small-business sites. Free scan returns a risk score and issue counts.
+
 ## Local SEO
 
 Boost your local presence and connect with audiences in your community.


### PR DESCRIPTION
Adds TrustYourWebsite to the **Technical SEO** section.

It's an automated scanner that audits small-business websites for GDPR / cookie-banner and accessibility (axe-core) compliance, returning a risk score and issue counts free (no signup); paid reports add full findings and fix instructions.

It's a compliance / site-quality auditor rather than a pure SEO tool, so please move or decline it if it's out of scope — but the auditing angle overlaps with the site-quality auditors already listed here (Siteliner, Sitebulb, SiteAnalyzer).

Disclosure: I'm the author of the tool.