### PR TITLE
Add NotFair – open-source Claude Code skills for SEO & paid ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ From keyword research to link analysis, these tools are the Swiss army knives of
 
 - [Bishopi.io](https://www.bishopi.io/) - Get Enterprise-Grade SEO and Domain Intelligence.
 
+- [NotFair](https://github.com/nowork-studio/NotFair) - Open-source Claude Code skills for SEO, Google Ads, and Meta Ads. Connects to live account data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP to run audits, keyword research, meta-tag optimization, schema markup, and ad management directly from your editor.
+
 ## Keyword Research
 
 Uncover high-potential keywords to target and captivate your audience.


### PR DESCRIPTION
Hi, thanks for maintaining this list — it's a great resource.

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)** (MIT, ~2.9k stars) to the **All in one SEO tools** section. NotFair is an open-source set of Claude Code skills that covers SEO work (site analysis, keyword research, meta-tag optimization, schema markup, GEO optimization, content writing) as well as Google Ads and Meta Ads management, all operating on live account data.

What makes it a bit different from the other tools here is that it works directly inside the editor through four MCP connections: **Google Ads MCP**, **Meta Ads MCP**, **Google Search Console MCP**, and **Google Analytics (GA4) MCP** — so the agent can read real performance data and apply changes in the same workflow.

I followed the contributing guidelines: only edited `README.md`, added the entry at the bottom of the relevant section.

Happy to reword the description, move it to a different section, or trim anything if it doesn't quite fit.