### PR TITLE
Add AI Crawler Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Ensure your website's foundation is solid for search engines and user experience
 
 - [LibreCrawl](https://librecrawl.com/) - Free, open-source SEO crawler with unlimited URL crawling, JavaScript rendering via Playwright, and real-time memory profiling for enterprise-scale audits.
 
+- [AI Crawler Bots](https://github.com/TryGeoSuite/ai-crawler-bots) - Open-source command-line tool and GitHub Action that audits robots.txt for AI crawler access, scores AI visibility, and analyzes server logs to see which AI bots crawled the site.
+
 ## Local SEO
 
 Boost your local presence and connect with audiences in your community.


### PR DESCRIPTION
Hi! Adding [AI Crawler Bots](https://github.com/TryGeoSuite/ai-crawler-bots) (npm: `@geosuite/ai-crawler-bots`), a free, open-source (MIT), zero-dependency Node CLI and GitHub Action that audits robots.txt for AI crawler access, computes an AI-visibility score, tests live reachability, and reads server access logs to see which AI bots crawled a site.

I appended it to the bottom of the Technical SEO section, per the contributing guide. Thanks for maintaining this list!