### PR TITLE
Add AI Readiness Checker to Validator / Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ Equip your browser with tools for quick and efficient SEO insights on the go.
 
 - [XML Sitemap Checker](https://www.xml-sitemaps.com/validate-xml-sitemap.html) - Validates XML sitemaps for errors.
 
+- [AI Readiness Checker](https://samedaydesk.com/tools/ai-readiness) - Checks whether AI search engines (ChatGPT, Perplexity, Claude, Google AI) can crawl and understand your site: AI-crawler access in robots.txt, JSON-LD structured data, title/meta, Open Graph, and sitemap. Free, no signup ([open-source CLI](https://github.com/epistemedeus/ai-readiness)).
+
 
 ## Social Media & Open Graph
 


### PR DESCRIPTION
Adds a free, no-signup tool that checks whether AI search engines (ChatGPT, Perplexity, Claude, Google AI) can crawl and understand a site: AI-crawler access in robots.txt, JSON-LD structured data, title/meta, Open Graph, and sitemap. Placed at the bottom of the **Validator / Checker** category per the contributing guide.

- Tool: https://samedaydesk.com/tools/ai-readiness (no signup)
- Open-source CLI: https://github.com/epistemedeus/ai-readiness (MIT)

AI-search readiness is an increasingly common SEO question and this fills a gap in the Validator / Checker section. Thanks for maintaining the list!