### PR TITLE
Add Edos SEO Scanner and GEO/AEO Scanner (Technical SEO)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ Ensure your website's foundation is solid for search engines and user experience
 
 - [LibreCrawl](https://librecrawl.com/) - Free, open-source SEO crawler with unlimited URL crawling, JavaScript rendering via Playwright, and real-time memory profiling for enterprise-scale audits.
 
+- [Edos SEO Scanner](https://edos.com.au/tools/seo-scanner/) - Free in-browser on-page SEO audit: 11 checks, a letter grade and plain-English fixes. No signup.
+
+- [Edos GEO/AEO Scanner](https://edos.com.au/tools/geo-aeo-scanner/) - Free AI-search readiness audit (structured data, content depth, citations) for Google AI Overviews, ChatGPT and Perplexity.
+
 ## Local SEO
 
 Boost your local presence and connect with audiences in your community.


### PR DESCRIPTION
Adding two free, in-browser SEO tools to the Technical SEO section:

- **Edos SEO Scanner** — on-page audit with 11 checks (title, meta, headings, alt text, canonical, Open Graph, viewport, robots, links, page size), a letter grade and plain-English fixes. No signup.
- **Edos GEO/AEO Scanner** — AI-search readiness audit (structured data, content depth, author/date signals, citations) for Google AI Overviews, ChatGPT and Perplexity.

Both run client-side, free, no login. Verified they don't already appear in the list. Thanks for maintaining this!