### PR TITLE
Add Website Speed Comparator to Local SEO section

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ Boost your local presence and connect with audiences in your community.
 
 - [Moz Local](https://moz.com/products/local) - Maximize your online visibility with Moz's powerful local SEO and reputation management tool.
 
+- [Website Speed Comparator](https://landing-five-dusky-44.vercel.app/comparar-velocidad) - Free tool to compare your website speed vs. a competitor using real Google PageSpeed data. No signup required.
+
 ## SEO Analytics
 
 - [Google Search Console](https://search.google.com/search-console/about) - Search Console tools and reports help you measure your site's Search traffic and performance, fix issues, and make your site shine in Google Search results


### PR DESCRIPTION
## Description

Adds a free, no-signup website speed comparison tool to the Local SEO section.

**Tool:** [Website Speed Comparator](https://landing-five-dusky-44.vercel.app/comparar-velocidad)

## Why it fits

The Local SEO section currently lists citation/rank-tracking tools (BrightLocal, Whitespark, LocalFalcon, Moz Local). This tool adds a different angle: **competitive speed analysis**.

Local businesses frequently ask "is my website slower than my competitor's?" — this tool answers that with real Google PageSpeed Insights data for two URLs side-by-side, in seconds, free, no account needed.

## What it does

- Enter two URLs → instant side-by-side PageSpeed scores (mobile)
- Shows Performance score, LCP, FCP, Speed Index for each
- Clear "winner" verdict + shareable result
- Uses Google PageSpeed Insights API (public, no key needed)

## Criteria check

- ✅ Free to use, no signup
- ✅ Directly useful for local SEO practitioners comparing their site vs. competitors
- ✅ Not duplicating any existing tool in the list