### PR TITLE
Add Revenue Grader to Miscellaneous Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Explore a diverse range of tools for those niche tasks and unique SEO challenges
   
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across AI tools. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+- [Revenue Grader](https://getrevenuegrader.com) - Free tool that scores whether ChatGPT, Claude, and Perplexity would cite a page (AEO/GEO), with subscores and fixes. No signup for the initial scan.
+
 Happy optimizing! 🚀
 
 ## Information


### PR DESCRIPTION
Adds one entry to **Miscellaneous Tools**: Revenue Grader, a free tool that scores whether ChatGPT, Claude, and Perplexity would cite a page (AEO/GEO) and returns subscores plus fixes. No signup for the initial scan.

It fits alongside the existing GEO/AEO Tracker entry in this section. Placed at the bottom of the category per CONTRIBUTING.

- https://getrevenuegrader.com