### PR TITLE
Add PublishPixel to Social Media & Open Graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ Tools for optimizing how your content appears when shared on social platforms.
 
 - [ogimg.xyz](https://ogimg.xyz/) - API for generating Open Graph images programmatically. 10 templates, custom branding, URL auto-fetch mode. Free tier available.
 
+- [PublishPixel](https://publishpixel.net/) - Free, in-browser image checks for SEO and social sharing: dimensions, file size, metadata, alt text, Open Graph readiness and exact platform image sizes. No upload, no signup.
+
 ## Miscellaneous Tools
 
 Explore a diverse range of tools for those niche tasks and unique SEO challenges.


### PR DESCRIPTION
Adds PublishPixel to the Social Media & Open Graph category (at the bottom, per the contributing guidelines).

PublishPixel is a free set of browser-based image tools relevant to SEO and social sharing: pre-publish image checks (dimensions, file size, metadata, alt text), Open Graph readiness, and a social media image-size reference for every major platform. Everything runs client-side (no upload) and requires no signup.

Disclosure: I'm the author of the tool. Checked that it's not already on the list.