### PR TITLE
Add SEO Report Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Explore a diverse range of tools for those niche tasks and unique SEO challenges
   
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across AI tools. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+- [SEO Report Kit](https://seoreportkit.com/tools/seo-report-brief-generator/) - Free, browser-based generators and original templates for client SEO reports, audits, keyword rankings, and AI visibility; no signup or data upload.
+
 Happy optimizing! 🚀
 
 ## Information


### PR DESCRIPTION
## What changed

- Add SEO Report Kit to the bottom of the Miscellaneous Tools section.
- Link directly to its free browser-based SEO report brief generator.

## Why

SEO Report Kit provides no-signup, local-browser generators and original templates for client SEO reports, audits, keyword rankings, and AI visibility. It fits the repository's collection of focused SEO utilities without presenting itself as a rank tracker or all-in-one platform.

## Checks

- Confirmed the entry is not already present.
- Confirmed the linked tool returns HTTP 200.
- Changed only `README.md`, as required by the contribution guide.
