### PR TITLE
Add Leaster Site-Check to Technical SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Ensure your website's foundation is solid for search engines and user experience
 
 - [LibreCrawl](https://librecrawl.com/) - Free, open-source SEO crawler with unlimited URL crawling, JavaScript rendering via Playwright, and real-time memory profiling for enterprise-scale audits.
 
+- [Leaster Site-Check](https://check.leaster.it) - Free, privacy-first website checker for SEO, AI visibility (GAIO/GEO), privacy, performance and accessibility. Open JSON API, no signup, no tracking.
+
 ## Local SEO
 
 Boost your local presence and connect with audiences in your community.


### PR DESCRIPTION
Adds [Leaster Site-Check](https://check.leaster.it) to the **Technical SEO** section.

A free, privacy-first website checker that audits SEO, AI visibility (GAIO/GEO), privacy & security, performance and accessibility, and returns the full report over an open JSON API — no signup, no tracking, and it doesn't log the checked URLs.

- Worked only on `README.md`
- Added at the bottom of the relevant category (Technical SEO)
- Verified it wasn't already listed