### PR TITLE
Add actablesite-check to technical SEO tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Ensure your website's foundation is solid for search engines and user experience
 
 - [LibreCrawl](https://librecrawl.com/) - Free, open-source SEO crawler with unlimited URL crawling, JavaScript rendering via Playwright, and real-time memory profiling for enterprise-scale audits.
 
+- [actablesite-check](https://github.com/unitedideas/actablesite-check) - Free, open-source CLI and GitHub Action that checks robots.txt policy for eight OpenAI, Anthropic, Perplexity, and Google AI crawler tokens.
+
 ## Local SEO
 
 Boost your local presence and connect with audiences in your community.


### PR DESCRIPTION
## What changed

Added `actablesite-check` to the Technical SEO section.

## Why

The project is a free, MIT-licensed CLI and GitHub Action focused on robots.txt policy for eight current AI crawler tokens. It complements the directory's existing crawler and robots.txt tools without duplicating an existing entry.

## Validation

- Changed only `README.md`, as requested by the contribution guide.
- Added the entry at the bottom of the relevant category.
- Confirmed the project is not already listed.
- Confirmed the linked public repository returns HTTP 200.
- Ran `git diff --check`.
