### PR TITLE
Add Rankfor.AI (AI visibility measurement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Explore a diverse range of tools for those niche tasks and unique SEO challenges
   
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across AI tools. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+- [Rankfor.AI](https://rankfor.ai/) - Measures how AI assistants (ChatGPT, Gemini, Perplexity) describe and recommend brands, per model and per language, with a repeated-query methodology published as open data.
+
 Happy optimizing! 🚀
 
 ## Information


### PR DESCRIPTION
Adds Rankfor.AI at the bottom of Miscellaneous Tools, per the contributing rules (README.md only, bottom of category, not in the list yet).

Rankfor.AI measures how AI assistants (ChatGPT, Gemini, Perplexity) describe and recommend brands, per model and per language. Methodology is published as open data: 167,551 AI answer citations analyzed (DOI: 10.5281/zenodo.20788142) plus a CC-BY-4.0 dataset on Kaggle.

Disclosure: I'm the founder. Happy to adjust wording or move it to another category.