### PR TITLE
Add HTML Outline Checker to Validator / Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ Equip your browser with tools for quick and efficient SEO insights on the go.
 
 - [XML Sitemap Checker](https://www.xml-sitemaps.com/validate-xml-sitemap.html) - Validates XML sitemaps for errors.
 
+- [HTML Outline Checker](https://codequest.work/generator/html-outline-checker/) - Paste HTML to validate heading hierarchy (outline), invalid tag nesting, duplicate classes, and missing alt/charset/title. Runs entirely in the browser; no data is sent. Free.
+
 
 ## Social Media & Open Graph
 


### PR DESCRIPTION
Adds **HTML Outline Checker** to the **Validator / Checker** category (appended to the bottom of the category, README.md only).

Link: https://codequest.work/generator/html-outline-checker/

Paste HTML to validate heading hierarchy (outline), invalid tag nesting, duplicate classes, and missing alt/charset/title. Runs entirely in the browser, free, no signup. Not already in the list.