### PR TITLE
Add website-seo-audit to Technical SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Ensure your website's foundation is solid for search engines and user experience
 
 - [LibreCrawl](https://librecrawl.com/) - Free, open-source SEO crawler with unlimited URL crawling, JavaScript rendering via Playwright, and real-time memory profiling for enterprise-scale audits.
 
+- [website-seo-audit](https://github.com/zxhydfzr/website-seo-audit) - Zero-dependency SEO auditor that crawls a site and grades on-page, technical, and JSON-LD structured-data signals; runs as a CLI or an AI agent skill.
+
 ## Local SEO
 
 Boost your local presence and connect with audiences in your community.


### PR DESCRIPTION
Adds **website-seo-audit** to the Technical SEO category.

- Repo: https://github.com/zxhydfzr/website-seo-audit
- What it is: a zero-dependency (Python stdlib only) SEO auditor that crawls a site and returns a graded report across on-page, technical, and JSON-LD/Schema.org structured-data checks. No API keys, no sign-up. Runs as a CLI or as an installable AI agent skill (Claude Code / Codex / opencode).

I confirmed it isn't already listed, edited only `README.md`, and appended the entry to the bottom of the Technical SEO section per the contributing notes.