### PR TITLE
Add goose-aeo to Miscellaneous Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Explore a diverse range of tools for those niche tasks and unique SEO challenges
 - [DebugBear](https://www.debugbear.com/test/website-speed) - Runs a page speed analysis and reports Google CrUX data
   
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across AI tools. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
+- [goose-aeo](https://github.com/gooseworks-ai/goose-aeo) - Open-source AEO tracking toolkit (CLI + dashboard) for checking and improving brand visibility across AI search engines: ChatGPT, Perplexity, Gemini, Grok, Claude, and DeepSeek.
 
 Happy optimizing! 🚀
 


### PR DESCRIPTION
Adds [goose-aeo](https://github.com/gooseworks-ai/goose-aeo) to the bottom of **Miscellaneous Tools**, next to the GEO/AEO Tracker it complements.

Open-source AEO tracking toolkit (CLI + dashboard) built for AI agents — set up tracking, run visibility analyses across ChatGPT, Perplexity, Gemini, Grok, Claude, and DeepSeek, audit sites for AI readability, and get actionable recommendations. Not already on the list (checked).

— Himanshu Bamoria, co-founder @ [GooseWorks](https://gooseworks.ai)

🤖 Generated with [Claude Code](https://claude.com/claude-code)