### PR TITLE
Add ImageSizeKit Open Graph Preview Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ Tools for optimizing how your content appears when shared on social platforms.
 
 - [ShotOG](https://github.com/nicepkg/shotog) - Open source, edge-native OG image generation API (~50ms) to boost social media click-through rates and improve content visibility.
 
+- [ImageSizeKit Open Graph Preview Checker](https://imagesizekit.com/open-graph-preview-checker/) - Browser-based checker for Open Graph preview image dimensions before publishing. Runs locally with no image upload required.
+
 - [ogimg.xyz](https://ogimg.xyz/) - API for generating Open Graph images programmatically. 10 templates, custom branding, URL auto-fetch mode. Free tier available.
 
 ## Miscellaneous Tools


### PR DESCRIPTION
Adds a browser-based Open Graph preview image dimension checker under Social Media & Open Graph.

It complements the existing OG image generation tools in this section by helping users verify a prepared image before publishing. The checker runs locally in the browser and does not require uploading the image.