### PR TITLE
Add CrawlFuse Monitor to Technical SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Ensure your website's foundation is solid for search engines and user experience
 
 - [LibreCrawl](https://librecrawl.com/) - Free, open-source SEO crawler with unlimited URL crawling, JavaScript rendering via Playwright, and real-time memory profiling for enterprise-scale audits.
 
+- [CrawlFuse Monitor](https://github.com/Mandrilsquad1441/crawlfuse-monitor) - Open-source GitHub Action that fails CI when HTTP status, canonical, meta robots, or X-Robots-Tag checks regress on selected public URLs.
+
 ## Local SEO
 
 Boost your local presence and connect with audiences in your community.


### PR DESCRIPTION
Adds CrawlFuse Monitor at the bottom of the Technical SEO section, following the repository contribution instructions.

CrawlFuse Monitor is a public MIT-licensed GitHub Action and Node CLI for detecting pass-to-fail HTTP status, canonical, meta robots, and X-Robots-Tag regressions on selected public URLs. The linked repository has a tagged v1 release and passing CI.

This pull request changes only README.md.