### PR TITLE
Add OpenGraph Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ Tools for optimizing how your content appears when shared on social platforms.
 
 - [ogimg.xyz](https://ogimg.xyz/) - API for generating Open Graph images programmatically. 10 templates, custom branding, URL auto-fetch mode. Free tier available.
 
+- [OpenGraph Studio](https://www.opengraph.website/) - Free, open-source browser tool to crop and compress 1200×630 Open Graph images, preview social cards, and generate OG/Twitter meta tags.
+
 ## Miscellaneous Tools
 
 Explore a diverse range of tools for those niche tasks and unique SEO challenges.


### PR DESCRIPTION
## What changed

Added OpenGraph Studio to the Social Media & Open Graph section.

## Why

OpenGraph Studio is a free, open-source browser tool for preparing 1200×630 Open Graph images, previewing social cards, and generating OG/Twitter meta tags.

## Validation

- Confirmed the listing does not already exist
- Confirmed the website returns HTTP 200
- Ran `git diff --check`
