### PR TITLE
Add Mydentify backlink checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Delve deep into your link profile and discover opportunities for growth and risk
 
 - [BacklinkScan](https://backlinkscan.com/) - Backlink Checker. Simple. Powerful.
 
+- [Mydentify Dofollow/Nofollow Backlink Checker](https://mydentify.com/tools/dofollow-nofollow-checker) - Free checker that scans a live page, follows safe redirects, and reports matching links as followed, nofollow, sponsored, or UGC.
+
 - Other "All in one SEO tools" offer this feature as well.
 
 ## Content Optimization


### PR DESCRIPTION
## What changed

- Added Mydentify's free Dofollow/Nofollow Backlink Checker to the bottom of the Backlink Analysis section.
- Linked directly to the public, account-free checker.

## Why

The tool fetches a public page, follows a bounded safe redirect chain, and reports matching links as followed, nofollow, sponsored, or UGC. That makes it a focused fit for the repository's Backlink Analysis category.

## Validation

- Confirmed the tool returns HTTP 200.
- Confirmed the page declares `index, follow` and a matching canonical URL.
- Confirmed Mydentify was not already present in the list.
- Ran `git diff --check`.

Disclosure: I maintain Mydentify and am submitting this entry from the founder account.
