### PR TITLE
Add ScrapTheWeb to Validator / Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ Equip your browser with tools for quick and efficient SEO insights on the go.
 
 - [XML Sitemap Checker](https://www.xml-sitemaps.com/validate-xml-sitemap.html) - Validates XML sitemaps for errors.
 
+- [ScrapTheWeb](https://scraptheweb.in/tools/) - Free browser-based SEO checkers: robots.txt tester covering AI crawlers, meta tag analyzer with pixel-width SERP preview, Open Graph checker and HTTP header/redirect tracer. No signup or usage limits.
+
 
 ## Social Media & Open Graph
 


### PR DESCRIPTION
Adds ScrapTheWeb to the Validator / Checker section.

Disclosure: this is my own site. It's a set of free browser-based SEO
checkers — robots.txt tester (covers Googlebot, Bingbot, GPTBot, ClaudeBot,
PerplexityBot and CCBot), meta tag analyzer with a pixel-width SERP preview,
Open Graph checker with per-platform previews, and an HTTP header/redirect
chain tracer. No signup, no daily limits, and everything runs client-side.

Small note while I was here: the existing "Robots.txt Checker" entry links to
Google's help page for the robots.txt Tester, which Google has since retired.
Happy to open a separate PR updating that entry if it would be useful.

Happy to adjust the wording or placement.
