### PR TITLE
Add SerpScale to All in one SEO tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ From keyword research to link analysis, these tools are the Swiss army knives of
 
 - [Bishopi.io](https://www.bishopi.io/) - Get Enterprise-Grade SEO and Domain Intelligence.
 
+- [SerpScale](https://www.serpscale.com/) - All-in-one SEO platform with keyword rank tracking, keyword research, site audits and backlink monitoring, plus Google Search Console and GA4 data in one dashboard.
+
 ## Keyword Research
 
 Uncover high-potential keywords to target and captivate your audience.


### PR DESCRIPTION
Adds SerpScale at the bottom of the "All in one SEO tools" category, following the contributing guidelines (README.md only, appended to the relevant category, not already in the list).

SerpScale is an all-in-one SEO platform: keyword rank tracking, keyword research, technical site audits and backlink monitoring, with Google Search Console and GA4 data in one dashboard. It has a free plan.

Disclosure: I'm affiliated with SerpScale. Happy to adjust the description if you'd like it shorter.