### PR TITLE
Add PageSpeed.ONE to Miscellaneous Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Explore a diverse range of tools for those niche tasks and unique SEO challenges
   
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across AI tools. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+- [PageSpeed.ONE](https://pagespeed.one/en) - Page speed monitoring with daily automated synthetic tests and current and historical CrUX field data for Core Web Vitals.
+
 Happy optimizing! 🚀
 
 ## Information


### PR DESCRIPTION
Adds PageSpeed.ONE at the bottom of the Miscellaneous Tools section, next to the page speed tools already listed there (GTmetrix, Pingdom, DebugBear), per the contributing note to put new links at the bottom of the relevant category.

- [PageSpeed.ONE](https://pagespeed.one/en) - Page speed monitoring with daily automated synthetic tests and current and historical CrUX field data for Core Web Vitals.

I'm a developer of PageSpeed.ONE, so treat this as a suggestion. Happy to adjust the wording or placement, or drop it, if it doesn't meet the bar.