### PR TITLE
Add Vaytric free broken link checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Ensure your website's foundation is solid for search engines and user experience
 - [BROWSEO](https://www.browseo.net) - See your site through the eyes of a search engine. BROWSEO gives you the type of x-ray vision that search engines have.
 
 - [linkok.com](https://linkok.com) - A modern broken link checker.
+- [Vaytric Link Health](https://vaytric.com/link-health/) - Free broken link checker (up to 10 URLs); paid full-site crawl CSV.
 
 - [PressProxy](https://pressproxy.io/) - No-code tool to serve blog.domain.tld on domain.tld/blog using Cloudflare Workers.
 


### PR DESCRIPTION
Adds [Vaytric Link Health](https://vaytric.com/link-health/) next to other broken link checkers.

- Free: check up to 10 URLs
- Optional paid full-site crawl CSV
- No signup for free tier