### PR TITLE
Add ProposalSprint to Content Optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Fine-tune your content to resonate with search algorithms and your audience alik
 - [Hypertxt](https://hypertxt.ai) - If Perplexity, ChatGPT and Ahrefs had a baby, you'd have Hypertxt. Generate deeply-researched SEO/GEO-optimized content.
 
 - [TuxSEO](https://tuxseo.com/) - Fully automated, SEO optimized, blog creation for your business.  
+
+- [ProposalSprint](https://proposalsprint.vercel.app/) - Turns discovery-call notes into a client-ready SEO proposal draft: scope, deliverables, timeline and pricing, formatted and ready to send.
  
 ## Rank Tracking
 


### PR DESCRIPTION
ProposalSprint (https://proposalsprint.vercel.app/) turns discovery-call notes into a client-ready SEO proposal draft — scope, deliverables, timeline and pricing, formatted and ready to send. Built for freelancers and agencies writing SEO proposals, so it fits the Content Optimization section. One line added at the end of that category, per the contributing guide.