### PR TITLE
Add OG Forge to Social Media & Open Graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ Tools for optimizing how your content appears when shared on social platforms.
 
 - [ogimg.xyz](https://ogimg.xyz/) - API for generating Open Graph images programmatically. 10 templates, custom branding, URL auto-fetch mode. Free tier available.
 
+- [OG Forge](https://github.com/percymcn/og-forge) - Free GitHub Action that generates Open Graph and Twitter card images in CI. Satori + resvg, fonts vendored, no headless browser required.
+
 ## Miscellaneous Tools
 
 Explore a diverse range of tools for those niche tasks and unique SEO challenges.


### PR DESCRIPTION
Adds [OG Forge](https://github.com/percymcn/og-forge) to the **Social Media & Open Graph** category.

**What it is:** a free, MIT-licensed GitHub Action that generates Open Graph / Twitter card images as part of CI, so every page ships with a correct social preview without manual design work.

**Why it fits this category:** the existing entries (ShotOG, ogimg.xyz) are hosted APIs. OG Forge covers the CI/build-time case instead — images are committed as static files, so there is no runtime dependency or per-image request cost.

**Details:**
- Renders with Satori + resvg — no headless browser, so it runs in a normal Actions runner
- Fonts are vendored, so output is deterministic across runners
- Live demo: https://percymcn.github.io/og-forge/demo/

Checked against the contributing rules: README.md only, appended to the bottom of the relevant category, and not already present in the list.