### PR TITLE
Add GEO-Score to Miscellaneous Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Explore a diverse range of tools for those niche tasks and unique SEO challenges
   
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across AI tools. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+- [GEO-Score](https://geo-score.online) – Free checker that scores any URL (0-100) on how well it's optimized to be cited by ChatGPT, Perplexity, Claude and Google AI Overviews. No signup required.
+
 Happy optimizing! 🚀
 
 ## Information


### PR DESCRIPTION
Adds GEO-Score (https://geo-score.online), a free no-signup checker that scores any URL (0-100) on how well it's optimized to be cited by ChatGPT, Perplexity, Claude and Google AI Overviews, based on 22 metrics. Added at the bottom of the Miscellaneous Tools category per the contributing guidelines; not yet in the list. Disclosure: I'm affiliated with the tool.