### PR TITLE
Add DomainScout to miscellaneous SEO tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Explore a diverse range of tools for those niche tasks and unique SEO challenges
   
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across AI tools. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+- [DomainScout](https://domainscout.dev/) - Real-time domain availability search with instant results across 46+ TLDs and free unlimited searches.
+
 Happy optimizing! 🚀
 
 ## Information


### PR DESCRIPTION
你好，我想补充一个与 Miscellaneous Tools 分类匹配的项目：DomainScout。

官方入口：https://domainscout.dev/
它用于实时查询域名可用性，覆盖 46+ TLD，并提供免费不限次数搜索和即时结果。

我是该项目维护者，先说明关系方便审核；这次只按现有格式增加一条事实性链接，不涉及付费推荐、互链或徽章。如果分类或描述需要调整，欢迎直接修改或关闭 PR。