### PR TITLE
Add Sitemap Cohort Auditor to Technical SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Ensure your website's foundation is solid for search engines and user experience
 
 - [LibreCrawl](https://librecrawl.com/) - Free, open-source SEO crawler with unlimited URL crawling, JavaScript rendering via Playwright, and real-time memory profiling for enterprise-scale audits.
 
+- [Sitemap Cohort Auditor](https://github.com/edilec/sitemap-cohort-auditor) - Open-source, dependency-free Node.js CLI for recursively auditing XML and GZip sitemaps, comparing URL and image cohorts, and producing deterministic JSON reports.
+
 ## Local SEO
 
 Boost your local presence and connect with audiences in your community.

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Ensure your website's foundation is solid for search engines and user experience
 
 - [LibreCrawl](https://librecrawl.com/) - Free, open-source SEO crawler with unlimited URL crawling, JavaScript rendering via Playwright, and real-time memory profiling for enterprise-scale audits.
 
-- [Sitemap Cohort Auditor](https://github.com/edilec/sitemap-cohort-auditor) - Open-source, dependency-free Node.js CLI for recursively auditing XML and GZip sitemaps, comparing URL and image cohorts, and producing deterministic JSON reports.
+- [Sitemap Cohort Auditor](https://github.com/edilec/sitemap-cohort-auditor) - Open-source, dependency-free Node.js CLI for recursively auditing XML and GZip sitemaps, measuring URL and image coverage, comparing URL cohorts, and producing deterministic JSON reports.
 
 ## Local SEO
 


### PR DESCRIPTION
## What changed

- Adds Sitemap Cohort Auditor to the bottom of the Technical SEO category.
- Links to the public, MIT-licensed repository and describes its sitemap audit and cohort-comparison capabilities.

## Why it fits

The tool recursively audits XML and GZip sitemap indexes, measures URL and image coverage, compares URL cohorts between releases, and emits deterministic JSON for CI or review. It is dependency-free and runs on supported Node.js versions.

## Validation

- Changed only `README.md`, as requested by the contribution guide.
- Confirmed the project is not already listed or proposed in an open issue/PR.
- Confirmed the repository and v0.1.1 release are public and the project CI passes on Node.js 20 and 24.

Disclosure: Edilec maintains the linked open-source project.
