### PR TITLE
Add BoastIndex to Technical SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Ensure your website's foundation is solid for search engines and user experience
 
 - [LibreCrawl](https://librecrawl.com/) - Free, open-source SEO crawler with unlimited URL crawling, JavaScript rendering via Playwright, and real-time memory profiling for enterprise-scale audits.
 
+- [BoastIndex](https://boastindex.com/) - Monitors Google Search Console index status on a schedule and provides URL-level history, change alerts, and reports.
+
 ## Local SEO
 
 Boost your local presence and connect with audiences in your community.


### PR DESCRIPTION
## What changed

Added BoastIndex to the bottom of the Technical SEO section.

## Why it fits

BoastIndex monitors index status reported by Google Search Console on a schedule. It stores URL-level history and provides change alerts and reports.

## Checks

- Changed only `README.md`.
- Confirmed BoastIndex is not already listed.
- Searched open and closed pull requests and open issues for duplicates.
- Verified https://boastindex.com/ is live.

Disclosure: I am affiliated with BoastIndex.
