### PR TITLE
Add Mentioned to Miscellaneous Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Explore a diverse range of tools for those niche tasks and unique SEO challenges
   
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across AI tools. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+- [Mentioned](https://mentioned.to/) - Done-for-you Reddit growth for search and AI visibility. Finds the Reddit threads already ranking on Google for your keywords, places your brand in them, and reports share of voice vs competitors.
+
 Happy optimizing! 🚀
 
 ## Information


### PR DESCRIPTION
Adds [Mentioned](https://mentioned.to/) at the bottom of *Miscellaneous Tools*, per the contributing notes (README.md only, appended to the relevant category, not already present).

Reddit threads rank for a large share of high-intent queries and are one of the most-cited sources in AI answers, but there's no tool in the list covering that surface. Mentioned finds the Reddit threads already ranking on Google for a site's keywords, places the brand in them, and reports share of voice against competitors.

It sits next to the existing GEO/AEO Tracker entry, which covers measuring AI visibility — this one covers earning it. One line added, no other changes.