### PR TITLE
feat(tools): add GEOKit to SEO tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Explore a diverse range of tools for those niche tasks and unique SEO challenges
   
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across AI tools. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+- [GEOKit](https://geokit.site) - Free, client-side Generative Engine Optimization (GEO) & AI SEO toolkit featuring llms.txt generators, AI crawler permissions manager, and AI search readiness audit.
+
 Happy optimizing! 🚀
 
 ## Information


### PR DESCRIPTION
### Summary

Adds [GEOKit](https://geokit.site) to the Miscellaneous / SEO Tools section.

- **Name**: GEOKit
- **Website**: https://geokit.site
- **Description**: Free, client-side Generative Engine Optimization (GEO) & AI SEO toolkit featuring llms.txt builders, AI robots.txt generator, Schema JSON-LD markup generators, and AI search readiness audits.