### PR TITLE
Add AdMapix to all in one SEO tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ From keyword research to link analysis, these tools are the Swiss army knives of
 
 - [DAXRM](https://www.daxrm.com/) - DAXRM is the all-in-one Digital Marketing CRM designed for agencies. Manage SEO, PPC, client reporting, and team collaboration in one seamless platform.
 
+- [AdMapix](https://www.admapix.com/) - Advertising intelligence for researching competitor creatives, campaigns, and market signals.
+
 - [SEO Toolbox](https://seotoolbox.site) – An all-in-one SEO platform that combines page-by-page analysis with AI powered insights and in-depth report generation, built for everyone from individuals to SEO agencies.
 
 - [Bishopi.io](https://www.bishopi.io/) - Get Enterprise-Grade SEO and Domain Intelligence.


### PR DESCRIPTION
Adds AdMapix to the all-in-one SEO tools section.

AdMapix is an advertising intelligence platform for researching competitor creatives, campaigns, and market signals, which makes it relevant to the list's existing digital marketing and competitive research coverage. The description is factual and links to the official site.

Disclosure: I am submitting this on behalf of the AdMapix team.