### PR TITLE
Add SitemapKit XML sitemap validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ Equip your browser with tools for quick and efficient SEO insights on the go.
 
 - [XML Sitemap Checker](https://www.xml-sitemaps.com/validate-xml-sitemap.html) - Validates XML sitemaps for errors.
 
+- [SitemapKit XML Sitemap Validator](https://sitemapkit.com/tools/sitemap-checker) - Free browser-based validator for malformed XML, invalid or duplicate URLs, sitemap size limits, and invalid `lastmod` dates.
+
 
 ## Social Media & Open Graph
 


### PR DESCRIPTION
## What

Adds SitemapKit to the Validator / Checker category.

## Why

The free browser tool checks sitemap XML structure, absolute and duplicate URLs, the 50,000 URL / 50 MB protocol limits, and invalid `lastmod` dates. It complements the existing sitemap checker entry with a validator that reports the specific failures it finds.

Verified live: https://sitemapkit.com/tools/sitemap-checker