### PR TITLE
Add zens.ink — free open-source SEO CLI toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ From keyword research to link analysis, these tools are the Swiss army knives of
 Uncover high-potential keywords to target and captivate your audience.
 
 - [Google Keyword Planner](https://ads.google.com/home/tools/keyword-planner/) - Free tool from Google Ads that provides keyword ideas and traffic estimates.
+- [zens.ink](https://github.com/ZensInk/zens-ink-seo-package) - Free open-source SEO CLI toolkit (26 tools, pure Python stdlib, zero dependencies): keyword research, SERP difficulty scoring, site audit, GEO/AI-search visibility scoring, rank tracking — runs on free API tiers, no paid subscriptions. (`pip install zens-ink`)
 
 - [Keyword Tool](https://keywordtool.io/) - Find great keywords using Google Autocomplete.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ From keyword research to link analysis, these tools are the Swiss army knives of
 Uncover high-potential keywords to target and captivate your audience.
 
 - [Google Keyword Planner](https://ads.google.com/home/tools/keyword-planner/) - Free tool from Google Ads that provides keyword ideas and traffic estimates.
-- [zens.ink](https://github.com/ZensInk/zens-ink-seo-package) - Free open-source SEO CLI toolkit (26 tools, pure Python stdlib, zero dependencies): keyword research, SERP difficulty scoring, site audit, GEO/AI-search visibility scoring, rank tracking — runs on free API tiers, no paid subscriptions. (`pip install zens-ink`)
+- [zens.ink](https://github.com/ZensInk/zens-ink-seo-package) - Free open-source SEO CLI toolkit (19 tools, pure Python stdlib, zero dependencies): keyword research, SERP difficulty scoring, site audit, GEO/AI-search visibility scoring, rank tracking — runs on free API tiers, no paid subscriptions. (`pip install zens-ink`)
 
 - [Keyword Tool](https://keywordtool.io/) - Find great keywords using Google Autocomplete.
 


### PR DESCRIPTION
**zens.ink** — free, open-source SEO CLI toolkit for indie builders & developers.

`pip install zens-ink` · [PyPI](https://pypi.org/project/zens-ink/) · [GitHub](https://github.com/ZensInk/zens-ink-seo-package) · [Site](https://zens.ink)

- 19 tools, pure Python stdlib, **zero dependencies**
- Keyword research (Google Autocomplete), clustering, KGR analysis
- SERP-based keyword difficulty (brand-term fingerprinting, entry difficulty)
- Site audit (33 checks), on-page audit, search-intent analysis
- GEO score — AI-search visibility (16 dimensions)
- Rank tracking, competitor gap, Reddit blue-ocean keyword mining
- Zero-dependency MCP stdio server included
- MIT license, actively maintained (v1.4.5, Aug 2026)

Happy to adjust the entry format to match the list conventions. Thanks!