### PR TITLE
Add mesure-citations

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Explore a diverse range of tools for those niche tasks and unique SEO challenges
   
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across AI tools. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+- [mesure-citations](https://github.com/thomasmerlaud/mesure-citations) - Open-source tool measuring a brand's share of citations across ChatGPT, Perplexity, Gemini, Claude and Google AI Overviews. Deliberately manual rather than API-driven, so the numbers reflect what a real user sees. Node.js, zero dependencies, data stays local.
+
 Happy optimizing! 🚀
 
 ## Information


### PR DESCRIPTION
Adding [mesure-citations](https://github.com/thomasmerlaud/mesure-citations) at the bottom of **Miscellaneous Tools**, next to the other AI-visibility entry.

It measures a brand's share of citations across ChatGPT, Perplexity, Gemini, Claude and Google AI Overviews.

The distinguishing design choice: the survey is **manual by design**. The tool never queries the models — it freezes a question corpus, generates the scoring sheet, guides data entry and computes the result. API answers differ from what a logged-in user actually sees, and no API returns an AI Overview, so automating the survey would produce a more comfortable and less true number.

It separates real citations (source linked) from unlinked mentions, and reports which competitors get cited instead.

Node.js 18+, zero dependencies, no network calls, MIT. Checked it is not already in the list.