### PR TITLE
Add Rankrat to SEO Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ Boost your local presence and connect with audiences in your community.
 
 - [Google Search Console](https://search.google.com/search-console/about) - Search Console tools and reports help you measure your site's Search traffic and performance, fix issues, and make your site shine in Google Search results
  
+- [Rankrat](https://github.com/psyb0t/rankrat) - Self-hosted MCP and REST service that unifies Search Console, GA4, Bing Webmaster, PageSpeed, CrUX, Cloudflare, Clarity, and Google Tag Manager for agent-driven SEO operations.
+
 - [SEO Gets](https://seogets.com/) - Privacy-focused analytics tool built to replace Google Search Console for Agencies and Affiliates.
 
 ## SEO Browser Extensions


### PR DESCRIPTION
Adds my self-hosted MCP and REST service [Rankrat](https://github.com/psyb0t/rankrat) to SEO Analytics. It unifies Search Console, GA4, Bing Webmaster, PageSpeed, CrUX, Cloudflare, Clarity, and Google Tag Manager for agent-driven SEO operations.