### PR TITLE
Add KinetixSEO On-Page SEO Checker and Hreflang Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,10 @@ Equip your browser with tools for quick and efficient SEO insights on the go.
 
 - [XML Sitemap Checker](https://www.xml-sitemaps.com/validate-xml-sitemap.html) - Validates XML sitemaps for errors.
 
+- [On-Page SEO Checker](https://kinetixseo.com/on-page-seo-checker) - Free, no-signup checker for heading hierarchy order, alt text, internal linking, and canonical tags.
+
+- [Hreflang Checker](https://kinetixseo.com/tools/hreflang-checker) - Free hreflang validator for format, x-default, self-reference, and reciprocal return-tags.
+
 
 ## Social Media & Open Graph
 


### PR DESCRIPTION
Two free, no-signup checkers added to Validator / Checker: an on-page checker covering heading hierarchy order, alt text, internal links, and canonical tags, and an hreflang validator that also checks reciprocal return-tags (not just tag presence). Neither exists in the list yet.