### PR TITLE
Add two free client-side tools to Technical SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ Ensure your website's foundation is solid for search engines and user experience
 - [Server-side Rendering (SSR) Checker](https://www.crawlably.com/ssr-checker/) - Check any URL for SSR (Server-side rendering) by visually comparing server-side rendered version of a page with regular version.
 
 - [LibreCrawl](https://librecrawl.com/) - Free, open-source SEO crawler with unlimited URL crawling, JavaScript rendering via Playwright, and real-time memory profiling for enterprise-scale audits.
+- [Oxwyn LocalBusiness Schema Generator](https://www.oxwynstudio.com/tools/schema-generator) - Free LocalBusiness JSON-LD generator that runs entirely in the browser; nothing entered is sent to a server.
+- [Oxwyn llms.txt Generator](https://www.oxwynstudio.com/tools/llms-txt-generator) - Free client-side generator for llms.txt, the file that tells AI assistants how to read your site.
 
 ## Local SEO
 


### PR DESCRIPTION
Adds two free browser-based tools to the bottom of Technical SEO, per the contributing notes. Both run fully client-side, need no account, and collect nothing. Disclosure: I work at the studio that built them, so please close this if self-submissions are not wanted here.