### PR TITLE
Add SearchScope to SEO Browser Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ Equip your browser with tools for quick and efficient SEO insights on the go.
 
 - [SEO Sidebar](https://chromewebstore.google.com/detail/seo-sidebar/gmmiickdcmghfpliaiefhjafccapgmpp) - A browser extension that displays real-time on-page SEO data in a persistent side panel, with one-click export to text reports.
 
+- [SearchScope](https://www.khalidsemary.com/marketing-tools) - Free Chrome extension for source-versus-rendered checks, structured data, hreflang, HTTP status codes, and AI-crawler access signals.
+
   
 ## Validator / Checker
 


### PR DESCRIPTION
Adds SearchScope to the SEO Browser Extensions section.

SearchScope is a free, privacy-first Chrome extension for checking technical SEO, source-versus-rendered differences, structured data, hreflang, HTTP status codes, and AI-crawler access signals.

Chrome Web Store: https://chromewebstore.google.com/detail/searchscope-%E2%80%93-seo-aeo-geo/macdjilnpihfmidgdjlonjldaodpniop

Disclosure: I built and maintain SearchScope.