### PR TITLE
Add Greadme to Technical SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Ensure your website's foundation is solid for search engines and user experience
 
 - [LibreCrawl](https://librecrawl.com/) - Free, open-source SEO crawler with unlimited URL crawling, JavaScript rendering via Playwright, and real-time memory profiling for enterprise-scale audits.
 
+- [Greadme](https://www.greadme.com/) - Website audits for SEO, performance and AI visibility, with fixes you can copy. Includes a free Schema Validator and AI Access Checker that need no signup.
+
 ## Local SEO
 
 Boost your local presence and connect with audiences in your community.


### PR DESCRIPTION
Adds Greadme at the bottom of the Technical SEO category, per the contributing notes (README only, bottom of category, not already listed — I checked).

Greadme audits a page or a whole site for SEO, performance, accessibility, security and structured data, checks whether AI systems can access and cite the site, and turns every finding into a fix you can copy. Two parts are free with no signup: the Schema Validator (https://www.greadme.com/schema-validator) and the AI Access Checker (https://www.greadme.com/ai-access-checker).

Disclosure: I'm the founder.