### PR TITLE
Add SchemaForge to Technical SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Ensure your website's foundation is solid for search engines and user experience
 
 - [LibreCrawl](https://librecrawl.com/) - Free, open-source SEO crawler with unlimited URL crawling, JavaScript rendering via Playwright, and real-time memory profiling for enterprise-scale audits.
 
+- [SchemaForge](https://schemaforge.thememend.com) - Free JSON-LD structured data generator for 10 schema.org types that validates required fields before output.
+
 ## Local SEO
 
 Boost your local presence and connect with audiences in your community.


### PR DESCRIPTION
Adds **SchemaForge** (https://schemaforge.thememend.com) to the *Technical SEO* section (appended at the bottom, per the contribution note).

It's a free JSON-LD / schema.org structured-data generator covering 10 types (Product, Article, FAQPage, LocalBusiness, Review, Recipe, Event, Organization, BreadcrumbList, VideoObject) that validates the required fields before generating the markup, so you don't ship incomplete structured data.

- Single link added, matches the existing `- [Name](url) - Description.` format
- Disclosure: I'm involved with the tool; it's free to use, no signup.