### PR TITLE
Add YiceKit SEO Title Checker to Technical SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Ensure your website's foundation is solid for search engines and user experience
 
 - [LibreCrawl](https://librecrawl.com/) - Free, open-source SEO crawler with unlimited URL crawling, JavaScript rendering via Playwright, and real-time memory profiling for enterprise-scale audits.
 
+- [YiceKit SEO Title Checker](https://yicekit.com/tools/seo-title-checker/) - Free browser-based checker for Chinese and English title length, with a search-result preview and no login.
+
 ## Local SEO
 
 Boost your local presence and connect with audiences in your community.


### PR DESCRIPTION
## Why

The Technical SEO section does not currently include a focused title-length checker that works well with both Chinese and English text.

## What

Adds one factual README entry for the free YiceKit SEO Title Checker. It counts Unicode characters, gives a search-result preview, requires no login, and does not promise ranking improvements.

I maintain YiceKit and am disclosing that relationship. I checked that the URL is live and that YiceKit is not already listed in the README or existing issues/PRs.
