### PR TITLE
Add AltoRank to All in one SEO tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ From keyword research to link analysis, these tools are the Swiss army knives of
 - [SearchAtlas](https://searchatlas.com/) - AI-powered SEO platform with an [MCP server](https://github.com/Search-Atlas-Group/searchatlas-mcp-server) that exposes 16 tools for 
   keyword research, site auditing, content optimization, backlink analysis, PPC management, and LLM brand visibility monitoring directly inside AI assistants.
 
-- [AltoRank](https://github.com/AltoRank/altorank) - Open-source (AGPL-3.0) AI SEO content engine you can self-host. Keyword research, domain audit, article generation with scoring and fact-checking, rank tracking, and AI-visibility monitoring, publishing to 12 destinations. A person approves every article before it ships — the MCP server exposes no publish tool.
+- [AltoRank](https://github.com/AltoRank/altorank) - Open-source (AGPL-3.0) AI SEO content engine you can self-host. Keyword research, domain audit, article generation with scoring and fact-checking, rank tracking, and AI-visibility monitoring, publishing to 13 destinations. A person approves every article before it ships — the MCP server exposes no publish tool.
 
 ## Keyword Research
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ From keyword research to link analysis, these tools are the Swiss army knives of
 - [SearchAtlas](https://searchatlas.com/) - AI-powered SEO platform with an [MCP server](https://github.com/Search-Atlas-Group/searchatlas-mcp-server) that exposes 16 tools for 
   keyword research, site auditing, content optimization, backlink analysis, PPC management, and LLM brand visibility monitoring directly inside AI assistants.
 
+- [AltoRank](https://github.com/AltoRank/altorank) - Open-source (AGPL-3.0) AI SEO content engine you can self-host. Keyword research, domain audit, article generation with scoring and fact-checking, rank tracking, and AI-visibility monitoring, publishing to 12 destinations. A person approves every article before it ships — the MCP server exposes no publish tool.
+
 ## Keyword Research
 
 Uncover high-potential keywords to target and captivate your audience.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ From keyword research to link analysis, these tools are the Swiss army knives of
 - [SearchAtlas](https://searchatlas.com/) - AI-powered SEO platform with an [MCP server](https://github.com/Search-Atlas-Group/searchatlas-mcp-server) that exposes 16 tools for 
   keyword research, site auditing, content optimization, backlink analysis, PPC management, and LLM brand visibility monitoring directly inside AI assistants.
 
-- [AltoRank](https://github.com/AltoRank/altorank) - Open-source (AGPL-3.0) AI SEO content engine you can self-host. Keyword research, domain audit, article generation with scoring and fact-checking, rank tracking, and AI-visibility monitoring, publishing to 13 destinations. A person approves every article before it ships — the MCP server exposes no publish tool.
+- [AltoRank](https://github.com/AltoRank/altorank) - Open-source (AGPL-3.0) AI SEO content engine you can self-host. Keyword research, domain audit, article generation with scoring and fact-checking, rank tracking, and AI-visibility monitoring, publishing to 13 destinations. A person approves every article before it ships: no MCP tool or API call can publish a draft.
 
 ## Keyword Research
 


### PR DESCRIPTION
Adds [AltoRank](https://github.com/AltoRank/altorank) to the **All in one SEO tools** section.

It's an open-source (AGPL-3.0), self-hostable AI SEO content engine — keyword research, domain audit, article generation with scoring and fact-checking, rank tracking, AI-visibility monitoring, and publishing to 12 destinations. Every section on the list is currently closed-source SaaS, so hopefully a self-hostable entry is useful to readers.

The distinguishing design decision is that publishing is gated on a human: the MCP server exposes no publish tool at all, and `auto_generate` has no publish counterpart. That's checkable in the repo rather than a marketing claim.

Checklist:
- [x] Only `README.md` modified
- [x] Appended to the bottom of the relevant category
- [x] Not already in the list

Full disclosure: I'm the author. Happy to move it to GEO / AI Visibility or Content Optimization instead, reword the description, or close it if it's not a fit.