### PR TITLE
Add SEO Stack Tools to All in one SEO tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ From keyword research to link analysis, these tools are the Swiss army knives of
 - [SearchAtlas](https://searchatlas.com/) - AI-powered SEO platform with an [MCP server](https://github.com/Search-Atlas-Group/searchatlas-mcp-server) that exposes 16 tools for 
   keyword research, site auditing, content optimization, backlink analysis, PPC management, and LLM brand visibility monitoring directly inside AI assistants.
 
+- [SEO Stack Tools](https://seostacktools.com/) - Free all-in-one SEO and content toolkit with 100+ tools spanning technical SEO, keyword tools, backlink checkers, and content/writing, no signup required.
+
 ## Keyword Research
 
 Uncover high-potential keywords to target and captivate your audience.


### PR DESCRIPTION
I'm the maintainer of SEO Stack Tools (https://seostacktools.com/), a free, no-signup platform with 100+ tools covering technical SEO, keyword research, backlink checking, and content/writing. Submitting it for the "All in one SEO tools" section alongside the other suites already listed. Happy to adjust description, wording, or placement if it fits better elsewhere or doesn't meet the bar for this list.