### PR TITLE
Add LovedByAI to GEO / AI Visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ Monitor your website's position in search results and gauge your SEO strategies'
 
 - [LLM Optimizer](https://llmopt.metavert.io) - AI brand visibility tool (like SEO for LLMs, or GEO). Measures composite AI Visibility Scores with per-dimension analysis (YouTube, Reddit, search, LLM knowledge testing) and prioritized optimization recommendations. MCP-native access via Claude and other AI assistants.
 
+- [LovedByAI](https://www.lovedby.ai/) - WordPress plugin that makes existing pages readable and citable by AI assistants. Adds schema and FAQ markup, generates and maintains an llms.txt file, and tracks AI referral traffic and brand mentions from ChatGPT, Perplexity, Claude and Gemini.
+
 ## Technical SEO
 
 Ensure your website's foundation is solid for search engines and user experience.


### PR DESCRIPTION
Adds one tool to **GEO / AI Visibility**.

`- [LovedByAI](https://www.lovedby.ai/) - WordPress plugin that makes existing pages readable and citable by AI assistants...`

The two tools currently in this section both *measure* AI visibility. LovedByAI is on the implementation side: it adds schema and FAQ markup, generates and maintains `llms.txt`, and pushes changes for indexing, inside WordPress. It also reports AI referral traffic and brand mentions, so it fits the category on both counts.

Live on the WordPress.org plugin directory: https://wordpress.org/plugins/lovedbyai-seo-for-llms-and-ai-search/

**Per the contributing guidelines**
- [x] Only `README.md` edited
- [x] Link placed at the bottom of the relevant category
- [x] Confirmed it is not already in the list