### PR TITLE
Add Retainer OS — Starter to Miscellaneous Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ Explore a diverse range of tools for those niche tasks and unique SEO challenges
 
 - [DebugBear](https://www.debugbear.com/test/website-speed) - Runs a page speed analysis and reports Google CrUX data
 
+- [Retainer OS — Starter](https://eliteseo6.gumroad.com/l/ewvwy) - Notion template for solo and small SEO agencies to track client deliverables and retainer work in one board.
+
 Happy optimizing! 🚀
 
 ## Information


### PR DESCRIPTION
Adds one entry to Miscellaneous Tools: **Retainer OS — Starter**, a $19 Notion template for solo and small SEO agencies to track client deliverables and retainer work.

- Followed the contributing note: worked only on README.md, added the link at the bottom of the relevant category (Miscellaneous Tools), checked it doesn't already exist in the list.
- No unverifiable claims (no user counts, ratings, etc.) — just what it does.

Thanks for maintaining this list!