### PR TITLE
Add Sitemap Cohort Auditor to Technical SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,9 @@ Ensure your website's foundation is solid for search engines and user experience
 
 - [geo-lint](https://github.com/IJONIS/geo-lint) - First open-source linter for Generative Engine Optimization (GEO). 92 rules for AI search visibility including structured data, citation density, and answer-ready formatting. Agent-first JSON output for automated lint-fix loops.
 
+- [Sitemap Cohort Auditor](https://github.com/edilec/sitemap-cohort-auditor) - Dependency-free Node.js CLI for comparing sitemap URL cohorts, counting image entries, and reporting sitemap metadata issues.
+
+
 ## Local SEO
 
 Boost your local presence and connect with audiences in your community.


### PR DESCRIPTION
Adds one factual public MIT-licensed open-source tool to the Technical SEO category.

Sitemap Cohort Auditor is maintained by Edilec. It compares sitemap URL cohorts before and after a release, reports image declarations, and identifies sitemap metadata issues.